### PR TITLE
Fixes the clone method of the state reporter

### DIFF
--- a/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5StatelessTestsetInfoTreeReporter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5StatelessTestsetInfoTreeReporter.java
@@ -35,6 +35,11 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
             Object clone = super.clone(target);
 
             Class<?> cls = clone.getClass();
+
+            Class<?> themeClass = target.loadClass(Theme.class.getName());
+            @SuppressWarnings({ "rawtypes", "unchecked" })
+            Object clonedTheme = Enum.valueOf((Class) themeClass, getTheme().name());
+
             cls.getMethod("setPrintStacktraceOnError", boolean.class).invoke(clone, isPrintStacktraceOnError());
             cls.getMethod("setPrintStacktraceOnFailure", boolean.class).invoke(clone, isPrintStacktraceOnFailure());
             cls.getMethod("setPrintStderrOnError", boolean.class).invoke(clone, isPrintStderrOnError());
@@ -43,11 +48,11 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
             cls.getMethod("setPrintStdoutOnError", boolean.class).invoke(clone, isPrintStdoutOnError());
             cls.getMethod("setPrintStdoutOnFailure", boolean.class).invoke(clone, isPrintStdoutOnFailure());
             cls.getMethod("setPrintStdoutOnSuccess", boolean.class).invoke(clone, isPrintStdoutOnSuccess());
-            cls.getMethod("setTheme", Theme.class).invoke(clone, getTheme());
+            cls.getMethod("setTheme", themeClass).invoke(clone, clonedTheme);
 
             return clone;
         } catch (ReflectiveOperationException e) {
-            throw new IllegalStateException(e.getLocalizedMessage());
+            throw new IllegalStateException(e.getLocalizedMessage(), e);
         }
     }
 


### PR DESCRIPTION
I just tried it with version 1.2.0 and it works great : )

I did however notice another small issue when e.g. `<forkCount>` is set to a value > 1. When we clone the tree reporter in `JUnit5StatelessTestsetInfoTreeReporter#clone(ClassLoader)`, we need to use the Theme class from the given class loader instead of the class from our own class loader. Otherwise it gives an error when trying to set the theme on the cloned object via reflection.