### PR TITLE
Use newer Surefire, don't append `s` to elapsed times

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.fabriciorby</groupId>
     <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
-    <version>1.2.1</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>maven-surefire-junit5-tree-reporter</name>
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.surefire.version>3.1.0</maven.surefire.version>
+        <maven.surefire.version>3.1.2</maven.surefire.version>
         <maven-surefire.testsetInfoReporter>
             org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter
         </maven-surefire.testsetInfoReporter>

--- a/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
@@ -229,7 +229,7 @@ public class TreePrinter {
             }
 
             concatenateWithTestGroup(builder, testResult, !isBlank(testResult.getReportNameWithGroup()));
-            builder.a(" - " + classResults.get(treeLength).elapsedTimeAsString() + "s");
+            builder.a(" - " + classResults.get(treeLength).elapsedTimeAsString());
 
             println(builder.toString());
         }
@@ -264,7 +264,7 @@ public class TreePrinter {
         private void println(MessageBuilder builder) {
             println(getTestPrefix()
                     .a(builder)
-                    .a(" - " + testResult.elapsedTimeAsString() + "s")
+                    .a(" - " + testResult.elapsedTimeAsString())
                     .toString());
         }
 


### PR DESCRIPTION
Minimal changes to fix #50 – should be released as a new version due to updated dependency.