### PR TITLE
Fix for IndexOutOfBoundsException in TreePrinter Class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.fabriciorby</groupId>
     <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
 
     <name>maven-surefire-junit5-tree-reporter</name>

--- a/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
@@ -228,7 +228,7 @@ public class TreePrinter {
             }
 
             concatenateWithTestGroup(builder, testResult, !isBlank(testResult.getReportNameWithGroup()));
-            builder.a(" - " + classResults.get(treeLength).elapsedTimeAsString());
+            builder.a(" - " + testResult.elapsedTimeAsString());
 
             println(builder.toString());
         }


### PR DESCRIPTION
**Overview**

fixes [Issue #29](https://github.com/fabriciorby/maven-surefire-junit5-tree-reporter/issues/29), where an IndexOutOfBoundsException happened in the TreePrinter class when trying to access classResults with an index that was out of range.

**Problem Description**

The `treeLength` value was sometimes larger than the number of elements in classResults, which caused the code to try accessing an index that didn’t exist. This led to the exception.

Example Scenario

	•	Test Class Name: NestedExampleTest$InnerTest$InnerInnerTest
	•	Calculated treeLength: 2 (due to two $ characters)
	•	classResults.size(): 2 (with indices ranging from 0 to 1)

Attempting to access `classResults.get(2)` would throw an `IndexOutOfBoundsException` as the highest valid index is 1.

**Solution**

The fix involves using the elapsedTimeAsString() method from the current testResult directly, instead of accessing classResults with treeLength as an index. This ensures the displayed elapsed time is accurate and prevents potential indexing errors.

**Code Changes**

Old Code:
`builder.a(" - " + classResults.get(treeLength).elapsedTimeAsString());`

Updated Code:
`builder.a(" - " + testResult.elapsedTimeAsString());`

Benefits
	•	Prevents IndexOutOfBoundsException: Eliminates the possibility of indexing beyond the bounds of classResults.
	•	Simplified Logic: Reduces the complexity of indexing calculations and improves code maintainability.
	•	Accurate Timing: Ensures the elapsed time is sourced directly from the relevant testResult.