### PR TITLE
Fixes #59 - Include hide-succes-tests option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ The output can be printed using two Themes: UNICODE and ASCII (by default).
 ![Imgur](https://i.imgur.com/FzcIWwe.png "ASCII Output")
 
 
+## Reduce verbosity
+
+Output in large projects could become too verbose, making failures or errors difficult to find inside the printed trees.
+To reduce verbosity, you can a _hide successful results_ option can be configured as follows:
+
+```xml
+<statelessTestsetInfoReporter
+        implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+    <hideResultsOnSuccess>true</hideResultsOnSuccess>
+</statelessTestsetInfoReporter>
+```
+
 ## Failure details
 
 By default, `<consoleOutputReporter><disable>true</disable></consoleOutputReporter>` disables all console output. To debug test failures, it may be useful to see the console output and stack traces when a test fails. To do so, you can configure this extension like this:

--- a/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5StatelessTestsetInfoTreeReporter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5StatelessTestsetInfoTreeReporter.java
@@ -25,6 +25,7 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
     private boolean printStdoutOnError;
     private boolean printStdoutOnFailure;
     private boolean printStdoutOnSuccess;
+    private boolean hideResultsOnSuccess;
     private Theme theme = Theme.ASCII;
 
     @Override
@@ -48,6 +49,7 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
             cls.getMethod("setPrintStdoutOnError", boolean.class).invoke(clone, isPrintStdoutOnError());
             cls.getMethod("setPrintStdoutOnFailure", boolean.class).invoke(clone, isPrintStdoutOnFailure());
             cls.getMethod("setPrintStdoutOnSuccess", boolean.class).invoke(clone, isPrintStdoutOnSuccess());
+            cls.getMethod("setHideResultsOnSuccess", boolean.class).invoke(clone, isPrintStdoutOnSuccess());
             cls.getMethod("setTheme", themeClass).invoke(clone, clonedTheme);
 
             return clone;
@@ -98,6 +100,10 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
         return printStdoutOnSuccess;
     }
 
+    public boolean isHideResultsOnSuccess() {
+        return hideResultsOnSuccess;
+    }
+
     public void setPrintStacktraceOnError(boolean printStacktraceOnError) {
         this.printStacktraceOnError = printStacktraceOnError;
     }
@@ -130,6 +136,10 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
         this.printStdoutOnSuccess = printStdoutOnSuccess;
     }
 
+    public void setHideResultsOnSuccess(boolean hideResultsOnSuccess) {
+        this.hideResultsOnSuccess = hideResultsOnSuccess;
+    }
+
     public void setTheme(Theme theme) {
         this.theme = theme;
     }
@@ -154,6 +164,7 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
                 .printStdoutOnError(isPrintStdoutOnError())
                 .printStdoutOnFailure(isPrintStdoutOnFailure())
                 .printStdoutOnSuccess(isPrintStdoutOnSuccess())
+                .hideResultsOnSuccess(isHideResultsOnSuccess())
                 .usePhrasedClassNameInRunning(isUsePhrasedClassNameInRunning())
                 .usePhrasedClassNameInTestCaseSummary(isUsePhrasedClassNameInTestCaseSummary())
                 .theme(getTheme())

--- a/src/main/java/org/apache/maven/plugin/surefire/report/ReporterOptions.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/ReporterOptions.java
@@ -9,6 +9,7 @@ public class ReporterOptions {
     private final boolean printStdoutOnError;
     private final boolean printStdoutOnFailure;
     private final boolean printStdoutOnSuccess;
+    private final boolean hideResultsOnSuccess;
     private final Theme theme;
     private final boolean usePhrasedClassNameInRunning;
     private final boolean usePhrasedClassNameInTestCaseSummary;
@@ -22,6 +23,7 @@ public class ReporterOptions {
         this.printStdoutOnError = builder.printStdoutOnError;
         this.printStdoutOnFailure = builder.printStdoutOnFailure;
         this.printStdoutOnSuccess = builder.printStdoutOnSuccess;
+        this.hideResultsOnSuccess = builder.hideResultsOnSuccess;
         this.usePhrasedClassNameInRunning = builder.usePhrasedClassNameInRunning;
         this.usePhrasedClassNameInTestCaseSummary = builder.usePhrasedClassNameInTestCaseSummary;
         this.theme = builder.theme != null ? builder.theme : Theme.ASCII;
@@ -63,6 +65,10 @@ public class ReporterOptions {
         return printStdoutOnSuccess;
     }
 
+    public boolean isHIdeResultsOnSuccess() {
+        return hideResultsOnSuccess;
+    }
+
     public boolean isUsePhrasedClassNameInRunning() {
         return usePhrasedClassNameInRunning;
     }
@@ -84,6 +90,7 @@ public class ReporterOptions {
         private boolean printStdoutOnError;
         private boolean printStdoutOnFailure;
         private boolean printStdoutOnSuccess;
+        private boolean hideResultsOnSuccess;
         private Theme theme;
         private boolean usePhrasedClassNameInRunning;
         private boolean usePhrasedClassNameInTestCaseSummary;
@@ -132,6 +139,11 @@ public class ReporterOptions {
 
         public Builder printStdoutOnSuccess(boolean printStdoutOnSuccess) {
             this.printStdoutOnSuccess = printStdoutOnSuccess;
+            return this;
+        }
+
+        public Builder hideResultsOnSuccess(boolean hideResultsOnSuccess) {
+            this.hideResultsOnSuccess = hideResultsOnSuccess;
             return this;
         }
 

--- a/src/main/java/org/apache/maven/plugin/surefire/report/ReporterOptions.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/ReporterOptions.java
@@ -29,6 +29,10 @@ public class ReporterOptions {
         this.theme = builder.theme != null ? builder.theme : Theme.ASCII;
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     public Theme getTheme() {
         return theme;
     }
@@ -65,7 +69,7 @@ public class ReporterOptions {
         return printStdoutOnSuccess;
     }
 
-    public boolean isHIdeResultsOnSuccess() {
+    public boolean isHideResultsOnSuccess() {
         return hideResultsOnSuccess;
     }
 
@@ -75,10 +79,6 @@ public class ReporterOptions {
 
     public boolean isUsePhrasedClassNameInTestCaseSummary() {
         return usePhrasedClassNameInTestCaseSummary;
-    }
-
-    public static Builder builder() {
-        return new Builder();
     }
 
     public static final class Builder {

--- a/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
@@ -42,13 +42,13 @@ import static org.apache.maven.surefire.shared.utils.logging.MessageUtils.buffer
  */
 public class TreePrinter {
 
+    private static final int $ = 36;
     private final ConsoleLogger consoleLogger;
     private final List<WrappedReportEntry> classResults;
     private final List<WrappedReportEntry> testSetStats;
     private final List<String> sourceNames;
     private final Set<String> distinctSourceName;
     private final ReporterOptions options;
-    private static final int $ = 36;
 
     public TreePrinter(ConsoleLogger consoleLogger, List<WrappedReportEntry> classResults, List<WrappedReportEntry> testSetStats, ReporterOptions options) {
         this.consoleLogger = consoleLogger;
@@ -84,7 +84,7 @@ public class TreePrinter {
     }
 
     private boolean isSuccessPrintAllowed() {
-       return !options.isHIdeResultsOnSuccess();
+        return !options.isHideResultsOnSuccess();
     }
 
     private class TestPrinter {

--- a/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
@@ -78,9 +78,13 @@ public class TreePrinter {
                 .stream()
                 .map(TestPrinter::new)
                 .forEach(printer -> {
-                    printer.printTest();
+                    printer.printTest(isSuccessPrintAllowed());
                     printer.printDetails();
                 });
+    }
+
+    private boolean isSuccessPrintAllowed() {
+       return !options.isHIdeResultsOnSuccess();
     }
 
     private class TestPrinter {
@@ -123,13 +127,13 @@ public class TreePrinter {
             }
         }
 
-        private void printTest() {
+        private void printTest(boolean isPrintSuccessAllowed) {
             printClass();
             if (testResult.isErrorOrFailure()) {
                 printFailure();
             } else if (testResult.isSkipped()) {
                 printSkipped();
-            } else if (testResult.isSucceeded()) {
+            } else if (isPrintSuccessAllowed && testResult.isSucceeded()) {
                 printSuccess();
             }
         }

--- a/src/test/java/org/apache/maven/plugin/surefire/report/ConsoleTreeReporterTest.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/ConsoleTreeReporterTest.java
@@ -7,6 +7,7 @@ import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.logging.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -89,5 +90,55 @@ class ConsoleTreeReporterTest {
 
         //TODO see how to unit test this
     }
+
+    @Test
+    void testHideSuccess() {
+        //TestStarting parameters
+        SimpleReportEntry simpleReportEntry1 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest", "Nested Sample", null, null);
+        SimpleReportEntry simpleReportEntry2 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest", "Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry3 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest", "Inner Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry4 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Inner Inner Inner Test", null, null);
+
+        SimpleReportEntry firstTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest", "Nested Sample", "test", "Should not be displayed");
+        WrappedReportEntry wrappedReportEntry1 = new WrappedReportEntry(firstTest, ReportEntryType.SUCCESS, 1, stdout, stderr);
+
+        SimpleReportEntry secondTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest", "Nested Sample", "test2", "Should not be displayed");
+        WrappedReportEntry wrappedReportEntry2 = new WrappedReportEntry(secondTest, ReportEntryType.SUCCESS, 1, stdout, stderr);
+
+        SimpleReportEntry thirdTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest", "Inner Test", "test", "Inner failure test should be displayed");
+        WrappedReportEntry wrappedReportEntry3 = new WrappedReportEntry(thirdTest, ReportEntryType.FAILURE, 1, stdout, stderr);
+
+        SimpleReportEntry fourthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest", "Inner Inner Test", "test", "Inner Inner error test should be displayed");
+        WrappedReportEntry wrappedReportEntry4 = new WrappedReportEntry(fourthTest, ReportEntryType.ERROR, 1, stdout, stderr);
+
+        SimpleReportEntry fifthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Inner Inner Inner Test", "test", "Inner Inner Inner skipped test should be displayed");
+        WrappedReportEntry wrappedReportEntry5 = new WrappedReportEntry(fifthTest, ReportEntryType.SKIPPED, 1, stdout, stderr);
+
+        SimpleReportEntry sixthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$FirstInnerTest", "First Inner Test", "test", "FirstInnerTest should not be displayed");
+        WrappedReportEntry wrappedReportEntry6 = new WrappedReportEntry(sixthTest, ReportEntryType.SUCCESS, 1, stdout, stderr);
+
+        TestSetStats testSetStats = new TestSetStats(false, true);
+        testSetStats.testSucceeded(wrappedReportEntry1);
+        testSetStats.testSucceeded(wrappedReportEntry2);
+        testSetStats.testFailure(wrappedReportEntry3);
+        testSetStats.testError(wrappedReportEntry4);
+        testSetStats.testSkipped(wrappedReportEntry5);
+        testSetStats.testSucceeded(wrappedReportEntry6);
+
+        TestSetStats testSetStatsForClass = new TestSetStats(false, true);
+
+        ReporterOptions optionsHidingSuccess = ReporterOptions.builder().hideResultsOnSuccess(true).build();
+        ConsoleTreeReporter consoleTreeReporter = new ConsoleTreeReporter(new PluginConsoleLogger(logger), optionsHidingSuccess);
+        consoleTreeReporter.testSetStarting(simpleReportEntry1);
+        consoleTreeReporter.testSetStarting(simpleReportEntry2);
+        consoleTreeReporter.testSetStarting(simpleReportEntry3);
+        consoleTreeReporter.testSetStarting(simpleReportEntry4);
+        consoleTreeReporter.testSetCompleted(wrappedReportEntry5, testSetStats, null);
+        consoleTreeReporter.testSetCompleted(wrappedReportEntry4, testSetStatsForClass, null);
+        consoleTreeReporter.testSetCompleted(wrappedReportEntry3, testSetStatsForClass, null);
+        consoleTreeReporter.testSetCompleted(wrappedReportEntry2, testSetStatsForClass, null);
+
+    }
+
 
 }


### PR DESCRIPTION
I have provided the posibility to configure `statelessTestsetInfoReporter` with

```xml
<hideResultsOnSuccess>true</hideResultsOnSuccess>
```
Thus, green test cases will not show up in the output, but their class hierarchy and running time will.

Simple tests were added to confirm it works:
![image](https://github.com/user-attachments/assets/dee8f22f-6160-4241-96f1-3dbff8d428cd)

