### PR TITLE
Refactor the code to print the tests while traversing a tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ The output can be printed using two Themes: UNICODE and ASCII (by default).
 ```
 ![Imgur](https://i.imgur.com/FzcIWwe.png "ASCII Output")
 
+## Blank line between tests
+```xml
+<statelessTestsetInfoReporter
+        implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+    <printBlankLineBetweenTests>true</printBlankLineBetweenTests>
+</statelessTestsetInfoReporter>
+```
+
 
 ## Reduce verbosity
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.fabriciorby</groupId>
     <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>maven-surefire-junit5-tree-reporter</name>
@@ -216,6 +216,7 @@
                             <goal>sign</goal>
                         </goals>
                         <configuration>
+                            <skip>true</skip>
                             <gpgArguments>
                                 <arg>--pinentry-mode</arg>
                                 <arg>loopback</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
                     </consoleOutputReporter>
                     <statelessTestsetInfoReporter
                             implementation="${maven-surefire.testsetInfoReporter}">
+                        <printBlankLineBetweenTests>true</printBlankLineBetweenTests>
                         <theme>UNICODE</theme>
                     </statelessTestsetInfoReporter>
                 </configuration>

--- a/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5StatelessTestsetInfoTreeReporter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5StatelessTestsetInfoTreeReporter.java
@@ -26,6 +26,7 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
     private boolean printStdoutOnFailure;
     private boolean printStdoutOnSuccess;
     private boolean hideResultsOnSuccess;
+    private boolean printBlankLineBetweenTests;
     private Theme theme = Theme.ASCII;
 
     @Override
@@ -104,6 +105,10 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
         return hideResultsOnSuccess;
     }
 
+    public boolean isPrintBlankLineBetweenTests() {
+        return printBlankLineBetweenTests;
+    }
+
     public void setPrintStacktraceOnError(boolean printStacktraceOnError) {
         this.printStacktraceOnError = printStacktraceOnError;
     }
@@ -140,6 +145,10 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
         this.hideResultsOnSuccess = hideResultsOnSuccess;
     }
 
+    public void setPrintBlankLineBetweenTests(boolean printBlankLineBetweenTests) {
+        this.printBlankLineBetweenTests = printBlankLineBetweenTests;
+    }
+
     public void setTheme(Theme theme) {
         this.theme = theme;
     }
@@ -167,7 +176,9 @@ public class JUnit5StatelessTestsetInfoTreeReporter extends JUnit5StatelessTests
                 .hideResultsOnSuccess(isHideResultsOnSuccess())
                 .usePhrasedClassNameInRunning(isUsePhrasedClassNameInRunning())
                 .usePhrasedClassNameInTestCaseSummary(isUsePhrasedClassNameInTestCaseSummary())
+                .printBlankLineBetweenTests(isPrintBlankLineBetweenTests())
                 .theme(getTheme())
                 .build();
     }
+
 }

--- a/src/main/java/org/apache/maven/plugin/surefire/report/ActualTreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/ActualTreePrinter.java
@@ -1,0 +1,49 @@
+package org.apache.maven.plugin.surefire.report;
+
+import org.apache.maven.surefire.shared.utils.logging.MessageBuilder;
+
+import java.util.stream.LongStream;
+
+import static org.apache.maven.surefire.shared.utils.logging.MessageUtils.buffer;
+
+public class ActualTreePrinter {
+
+    private final Node tree;
+
+    public ActualTreePrinter(Node node) {
+        this.tree = node;
+    }
+
+    public void print() {
+        print(tree);
+    }
+
+    private void print(Node node) {
+        printName(node);
+        if (node.branches.isEmpty()) {
+            node.wrappedReportEntries.forEach(i -> printTestFormated(node, i));
+        }
+        node.wrappedReportEntries.forEach(i -> printTestFormated(node, i));
+        node.branches.forEach(this::print);
+    }
+
+    private void printTestFormated(Node node, WrappedReportEntry entry) {
+        Theme theme = Theme.UNICODE;
+        MessageBuilder builder = buffer();
+        builder.a(theme.pipe());
+        LongStream.rangeClosed(0, node.getDepth())
+                .forEach(w -> builder.a(theme.blank()));
+        builder.a(entry.getSourceName());
+        System.out.println(builder);
+    }
+
+    private void printName(Node node) {
+        Theme theme = Theme.UNICODE;
+        MessageBuilder builder = buffer();
+        builder.a(theme.pipe());
+        LongStream.rangeClosed(0, node.getDepth() - 1)
+                .forEach(w -> builder.a(theme.blank()));
+        builder.a(node.getName());
+        System.out.println(builder);
+    }
+}

--- a/src/main/java/org/apache/maven/plugin/surefire/report/ActualTreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/ActualTreePrinter.java
@@ -2,12 +2,14 @@ package org.apache.maven.plugin.surefire.report;
 
 import org.apache.maven.surefire.shared.utils.logging.MessageBuilder;
 
+import java.util.List;
 import java.util.stream.LongStream;
 
+import static org.apache.maven.plugin.surefire.report.TextFormatter.abbreviateName;
 import static org.apache.maven.surefire.shared.utils.logging.MessageUtils.buffer;
 
 public class ActualTreePrinter {
-
+    private final Theme theme = Theme.UNICODE;
     private final Node tree;
 
     public ActualTreePrinter(Node node) {
@@ -15,35 +17,112 @@ public class ActualTreePrinter {
     }
 
     public void print() {
-        print(tree);
+        print(tree.branches.get(0));
     }
 
     private void print(Node node) {
-        printName(node);
-        if (node.branches.isEmpty()) {
-            node.wrappedReportEntries.forEach(i -> printTestFormated(node, i));
-        }
+        printClass(node);
         node.wrappedReportEntries.forEach(i -> printTestFormated(node, i));
         node.branches.forEach(this::print);
     }
 
-    private void printTestFormated(Node node, WrappedReportEntry entry) {
-        Theme theme = Theme.UNICODE;
-        MessageBuilder builder = buffer();
-        builder.a(theme.pipe());
-        LongStream.rangeClosed(0, node.getDepth())
-                .forEach(w -> builder.a(theme.blank()));
-        builder.a(entry.getSourceName());
-        System.out.println(builder);
+    private void printTestFormated(Node node, WrappedReportEntry testResult) {
+//        if (testResult.isErrorOrFailure()) {
+//            printFailure();
+//        } else if (testResult.isSkipped()) {
+//            printSkipped();
+//        } else if (isPrintSuccessAllowed && testResult.isSucceeded()) {
+        printSuccess(node, testResult);
+//        }
+
     }
 
-    private void printName(Node node) {
-        Theme theme = Theme.UNICODE;
+    private void printSuccess(Node node, WrappedReportEntry testResult) {
+        printTestResult(buffer().success(theme.successful() + abbreviateName(testResult.getReportName())), node, testResult);
+    }
+
+    private void printTestResult(MessageBuilder builder, Node node, WrappedReportEntry testResult) {
+        println(getTestPrefix(node, testResult)
+                .a(builder)
+                .a(" - " + testResult.elapsedTimeAsString())
+                .toString());
+    }
+
+    private void println(String message) {
+//        consoleLogger.info(message);
+        System.out.println(message);
+    }
+
+    private boolean isLastMissingBranch(Node node) {
+        Node rootChild = Node.getRoot().branches.get(0); // first after ROOT
+        if (rootChild.hasBranches()) {
+            Node rootChildLastChild = getLastItem(rootChild.branches); // last branch in root child
+            return node.getParent(rootChildLastChild.getName()).isPresent() || node == rootChildLastChild;
+        } else {
+            return true;
+        }
+    }
+
+    private <T> T getLastItem(List<T> list) {
+        return list.get(list.size() - 1);
+    }
+
+    private MessageBuilder getTestPrefix(Node node, WrappedReportEntry testResult) {
         MessageBuilder builder = buffer();
-        builder.a(theme.pipe());
-        LongStream.rangeClosed(0, node.getDepth() - 1)
-                .forEach(w -> builder.a(theme.blank()));
+        if (isLastMissingBranch(node))
+            builder.a(theme.blank());
+        else
+            builder.a(theme.pipe());
+        if (node.getDepth() > 1) {
+            LongStream.rangeClosed(0, node.getDepth() - 3)
+                    .forEach(i -> builder.a(theme.blank()));
+            if (node.getParent().hasBranches() && node.hasBranches()
+            ) {
+                builder.a(theme.pipe());
+            } else {
+                builder.a(theme.blank());
+            }
+        }
+        if (isLastTestToBeEval(node, testResult)) {
+            builder.a(theme.entry());
+        } else {
+            builder.a(theme.end());
+        }
+        return builder;
+    }
+
+    private static boolean isLastTestToBeEval(Node node, WrappedReportEntry testResult) {
+        return node.wrappedReportEntries.indexOf(testResult) + 1 != node.wrappedReportEntries.size();
+    }
+
+    private void printClass(Node node) {
+        MessageBuilder builder = buffer();
+        if (node.getDepth() > 1) {
+            if (node.getDepth() > 2) {
+                if (isLastMissingBranch(node)) builder.a(theme.blank());
+                else builder.a(theme.pipe());
+                LongStream.rangeClosed(0, node.getDepth() - 4)
+                        .forEach(i -> builder.a(theme.blank()));
+                builder.a(theme.end());
+            } else {
+                if (isLastMissingBranch(node)) builder.a(theme.end());
+                else builder.a(theme.entry());
+            }
+            if (node.hasBranches()) {
+                builder.a(theme.down());
+            } else {
+                builder.a(theme.dash());
+            }
+        } else {
+            if (node.hasBranches()) builder.a(theme.down());
+            else builder.a(theme.dash());
+        }
+
         builder.a(node.getName());
-        System.out.println(builder);
+
+//        concatenateWithTestGroup(builder, testResult, !isBlank(testResult.getReportNameWithGroup()));
+//        builder.a(" - " + classResults.get(treeLength).elapsedTimeAsString());
+
+        println(builder.toString());
     }
 }

--- a/src/main/java/org/apache/maven/plugin/surefire/report/ActualTreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/ActualTreePrinter.java
@@ -25,8 +25,9 @@ public class ActualTreePrinter {
     }
 
     public void print() {
+        if (options.isPrintBlankLineBetweenTests()) println("");
         print(tree.branches.get(0));
-        Node.getRoot().clearTree();
+        Node.clearTree();
     }
 
     private void print(Node node) {
@@ -63,11 +64,10 @@ public class ActualTreePrinter {
 
     private void println(String message) {
         consoleLogger.info(message);
-        //System.out.println(message);
     }
 
     private boolean isLastMissingBranch(Node node) {
-        Node rootChild = Node.getRoot().branches.get(0); // first after ROOT
+        Node rootChild = tree.branches.get(0); // first after ROOT
         if (rootChild.hasBranches()) {
             Node rootChildLastChild = getLastItem(rootChild.branches); // last branch in root child
             return node.getParent(rootChildLastChild.getName()).isPresent() || node == rootChildLastChild;
@@ -76,7 +76,7 @@ public class ActualTreePrinter {
         }
     }
 
-    private <T> T getLastItem(List<T> list) {
+    private static <T> T getLastItem(List<T> list) {
         return list.get(list.size() - 1);
     }
 
@@ -121,23 +121,26 @@ public class ActualTreePrinter {
                 if (isLastMissingBranch(node)) builder.a(theme.end());
                 else builder.a(theme.entry());
             }
-            if (node.hasBranches()) {
-                builder.a(theme.down());
-            } else {
-                builder.a(theme.dash());
-            }
+        }
+        if (node.hasBranches()) {
+            builder.a(theme.down());
         } else {
-            if (node.hasBranches()) builder.a(theme.down());
-            else builder.a(theme.dash());
+            builder.a(theme.dash());
         }
 
-        builder.a(node.getName());
-
-//TODO: Fix this, compare with the timing from the other printer (for nested class names)
-//        concatenateWithTestGroup(builder, testResult, !isBlank(testResult.getReportNameWithGroup()));
-//        builder.a(" - " + classResults.get(treeLength).elapsedTimeAsString());
+        builder.strong(cleanReportName(node));
+        builder.a(" - " + node.getClassReportEntry().elapsedTimeAsString());
 
         println(builder.toString());
+    }
+
+    private String cleanReportName(Node node) {
+        if (node.getParent().getClassReportEntry() != null) {
+            int stringSizeToRemove = node.getParent().getClassReportEntry().getReportNameWithGroup().length() + 1;
+            return node.getClassReportEntry().getReportNameWithGroup().substring(stringSizeToRemove);
+        } else {
+            return node.getClassReportEntry().getReportNameWithGroup();
+        }
     }
 
     private void printDetails(WrappedReportEntry testResult) {
@@ -185,7 +188,6 @@ public class ActualTreePrinter {
     }
 
     private void printPreambleDetails(WrappedReportEntry testResult) {
-        println("");
         if (testResult.isSucceeded()) {
             println(buffer().success(theme.details()).success(abbreviateName(testResult.getReportName())).toString());
         } else {

--- a/src/main/java/org/apache/maven/plugin/surefire/report/Node.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/Node.java
@@ -1,0 +1,53 @@
+package org.apache.maven.plugin.surefire.report;
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Node {
+    private final List<Node> branches = new ArrayList<>();
+    private Node previous;
+    private String name;
+    private int nestLevel;
+
+    Node(String name, int nestLevel) {
+        this.name = name;
+        this.nestLevel = nestLevel;
+    }
+
+    public Node addNode(ReportEntry reportEntry) {
+        String[] nodes = reportEntry.getSourceName().split("\\$", -1);
+        return addChild(nodes, 1);
+    }
+
+    private Node addChild(String[] nodes, int nestLevel) {
+        if (nodes.length == nestLevel - 1) {
+            return new Node(nodes[nestLevel - 2], nestLevel - 2);
+        }
+        Node node;
+        if (contains(nodes[nestLevel -1]))
+            node = branches.get(branches.indexOf(new Node(nodes[nestLevel - 1], nestLevel)));
+        else {
+            node = new Node(nodes[nestLevel - 1], nestLevel);
+            this.branches.add(node);
+        }
+        return node.addChild(nodes, nestLevel + 1);
+    }
+
+    private boolean contains(String reportName) {
+        return branches.stream().anyMatch((item) -> item.name.equals(reportName));
+    }
+
+    private String getSourceRootName(ReportEntry reportEntry) {
+        return reportEntry.getSourceName().split("\\$", -1)[0];
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Node)
+            return ((Node) obj).name.equals(this.name);
+        else
+            return false;
+    }
+}

--- a/src/main/java/org/apache/maven/plugin/surefire/report/Node.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/Node.java
@@ -3,44 +3,94 @@ package org.apache.maven.plugin.surefire.report;
 import org.apache.maven.surefire.api.report.ReportEntry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class Node {
-    private final List<Node> branches = new ArrayList<>();
-    private Node previous;
-    private String name;
-    private int nestLevel;
+    private static final Node ROOT = new Node("ROOT", 0);
+    final List<Node> branches = new ArrayList<>();
+    private final Node parent;
+    private final String name;
+    private final int depth;
+    public final List<WrappedReportEntry> wrappedReportEntries = new ArrayList<>();
 
-    Node(String name, int nestLevel) {
+    public String getName() {
+        return name;
+    }
+
+    public int getDepth() {
+        return depth;
+    }
+
+    public static Node getRoot() {
+        return ROOT;
+    }
+
+    private Node(String name, int nestLevel) {
+        this(name, nestLevel, null);
+    }
+
+    private Node(String name, int depth, Node parent) {
         this.name = name;
-        this.nestLevel = nestLevel;
+        this.depth = depth;
+        this.parent = parent;
+    }
+
+    Node(String name, Node parent) {
+        this.name = name;
+        this.depth = parent.depth + 1;
+        this.parent = parent;
     }
 
     public Node addNode(ReportEntry reportEntry) {
         String[] nodes = reportEntry.getSourceName().split("\\$", -1);
-        return addChild(nodes, 1);
+        return addChildren(nodes);
     }
 
-    private Node addChild(String[] nodes, int nestLevel) {
-        if (nodes.length == nestLevel - 1) {
-            return new Node(nodes[nestLevel - 2], nestLevel - 2);
-        }
-        Node node;
-        if (contains(nodes[nestLevel -1]))
-            node = branches.get(branches.indexOf(new Node(nodes[nestLevel - 1], nestLevel)));
-        else {
-            node = new Node(nodes[nestLevel - 1], nestLevel);
-            this.branches.add(node);
-        }
-        return node.addChild(nodes, nestLevel + 1);
+    protected Node addChildren(String... nodes) {
+        return addChildren(Arrays.stream(nodes).collect(Collectors.toList()));
     }
 
-    private boolean contains(String reportName) {
+    protected Node addChildren(List<String> nodes) {
+        if (nodes.isEmpty()) return this;
+        return getBranchNode(nodes.get(0))
+                .orElseGet(() -> generateBranch(nodes.get(0)))
+                .addChildren(removeFirst(nodes));
+    }
+
+    private Node generateBranch(String name) {
+        Node branch = new Node(name,this);
+        branches.add(branch);
+        return branch;
+    }
+
+    private <T> List<T> removeFirst(List<T> list) {
+        return list.subList(1, list.size());
+    }
+
+    boolean containsBranch(String reportName) {
         return branches.stream().anyMatch((item) -> item.name.equals(reportName));
     }
 
-    private String getSourceRootName(ReportEntry reportEntry) {
-        return reportEntry.getSourceName().split("\\$", -1)[0];
+    Optional<Node> getBranchNode(String reportName) {
+        return branches.stream()
+                .filter((item) -> item.name.equals(reportName))
+                .findFirst();
+    }
+
+    Optional<Node> getBranchNode(List<String> nodePath) {
+        return getBranchNode(this, nodePath);
+    }
+
+    static Optional<Node> getBranchNode(Node node, List<String> nodePath) {
+        if (nodePath.size() == 1) {
+            return node.getBranchNode(nodePath.get(0));
+        }
+        if (node.getBranchNode(nodePath.get(0)).isPresent())
+            return getBranchNode(node.getBranchNode(nodePath.get(0)).get(), nodePath.subList(1, nodePath.size()));
+        return Optional.empty();
     }
 
     @Override
@@ -49,5 +99,9 @@ public class Node {
             return ((Node) obj).name.equals(this.name);
         else
             return false;
+    }
+
+    public Node getParent() {
+        return this.parent;
     }
 }

--- a/src/main/java/org/apache/maven/plugin/surefire/report/Node.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/Node.java
@@ -16,6 +16,10 @@ public class Node {
     private final int depth;
     public final List<WrappedReportEntry> wrappedReportEntries = new ArrayList<>();
 
+    public void clearTree() {
+        ROOT.branches.clear();
+    }
+
     public String getName() {
         return name;
     }
@@ -26,6 +30,10 @@ public class Node {
 
     public static Node getRoot() {
         return ROOT;
+    }
+
+    public boolean hasBranches() {
+       return !branches.isEmpty();
     }
 
     private Node(String name, int nestLevel) {
@@ -91,6 +99,12 @@ public class Node {
         if (node.getBranchNode(nodePath.get(0)).isPresent())
             return getBranchNode(node.getBranchNode(nodePath.get(0)).get(), nodePath.subList(1, nodePath.size()));
         return Optional.empty();
+    }
+
+    public Optional<Node> getParent(String parentName) {
+        if (parent == null) return Optional.empty();
+        if (parent.getName().equals(parentName)) return Optional.of(parent);
+        return parent.getParent(parentName);
     }
 
     @Override

--- a/src/main/java/org/apache/maven/plugin/surefire/report/Node.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/Node.java
@@ -1,6 +1,7 @@
 package org.apache.maven.plugin.surefire.report;
 
 import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.SimpleReportEntry;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,8 +16,9 @@ public class Node {
     private final String name;
     private final int depth;
     public final List<WrappedReportEntry> wrappedReportEntries = new ArrayList<>();
+    private WrappedReportEntry classReportEntry;
 
-    public void clearTree() {
+    public static void clearTree() {
         ROOT.branches.clear();
     }
 
@@ -117,5 +119,13 @@ public class Node {
 
     public Node getParent() {
         return this.parent;
+    }
+
+    public WrappedReportEntry getClassReportEntry() {
+        return classReportEntry;
+    }
+
+    public void setClassReportEntry(WrappedReportEntry classReportEntry) {
+        this.classReportEntry = classReportEntry;
     }
 }

--- a/src/main/java/org/apache/maven/plugin/surefire/report/ReporterOptions.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/ReporterOptions.java
@@ -13,6 +13,7 @@ public class ReporterOptions {
     private final Theme theme;
     private final boolean usePhrasedClassNameInRunning;
     private final boolean usePhrasedClassNameInTestCaseSummary;
+    private final boolean printBlankLineBetweenTests;
 
     private ReporterOptions(Builder builder) {
         this.printStacktraceOnError = builder.printStacktraceOnError;
@@ -27,6 +28,7 @@ public class ReporterOptions {
         this.usePhrasedClassNameInRunning = builder.usePhrasedClassNameInRunning;
         this.usePhrasedClassNameInTestCaseSummary = builder.usePhrasedClassNameInTestCaseSummary;
         this.theme = builder.theme != null ? builder.theme : Theme.ASCII;
+        this.printBlankLineBetweenTests = builder.printBlankLineBetweenTests;
     }
 
     public static Builder builder() {
@@ -81,6 +83,10 @@ public class ReporterOptions {
         return usePhrasedClassNameInTestCaseSummary;
     }
 
+    public boolean isPrintBlankLineBetweenTests() {
+        return printBlankLineBetweenTests;
+    }
+
     public static final class Builder {
         private boolean printStacktraceOnError;
         private boolean printStacktraceOnFailure;
@@ -94,6 +100,7 @@ public class ReporterOptions {
         private Theme theme;
         private boolean usePhrasedClassNameInRunning;
         private boolean usePhrasedClassNameInTestCaseSummary;
+        private boolean printBlankLineBetweenTests;
 
         private Builder() {
         }
@@ -159,6 +166,11 @@ public class ReporterOptions {
 
         public Builder usePhrasedClassNameInTestCaseSummary(boolean usePhrasedClassNameInTestCaseSummary) {
             this.usePhrasedClassNameInTestCaseSummary = usePhrasedClassNameInTestCaseSummary;
+            return this;
+        }
+
+        public Builder printBlankLineBetweenTests(boolean printBlankLineBetweenTests) {
+            this.printBlankLineBetweenTests = printBlankLineBetweenTests;
             return this;
         }
     }

--- a/src/main/java/org/apache/maven/plugin/surefire/report/TestReportHandler.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TestReportHandler.java
@@ -17,6 +17,7 @@ import static java.util.Collections.singletonList;
 
 public class TestReportHandler {
 
+    protected static final Node node = new Node("ROOT", 0);
     protected static final Map<String, Set<String>> classNames = new ConcurrentHashMap<>();
     protected static final Map<String, List<WrappedReportEntry>> classEntries = new ConcurrentHashMap<>();
     protected static final Map<String, List<WrappedReportEntry>> testEntries = new ConcurrentHashMap<>();
@@ -37,6 +38,7 @@ public class TestReportHandler {
     }
 
     public void prepare() {
+        node.addNode(report);
         if (hasNestedTests()) {
             markClassNamesForNestedTests();
         }

--- a/src/main/java/org/apache/maven/plugin/surefire/report/TestReportHandler.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TestReportHandler.java
@@ -42,21 +42,16 @@ public class TestReportHandler {
     public void print(BiFunction<List<WrappedReportEntry>, List<WrappedReportEntry>, TreePrinter> getTreePrinter) {
         if (testSetStats != null) {
             testSetStats.getReportEntries()
-                    .forEach(entry -> node.getBranchNode(node, getTestClassPath(entry.getSourceName())).get().wrappedReportEntries.add(entry));
+                    .forEach(entry -> Node.getBranchNode(node, getTestClassPath(entry.getSourceName())).get().wrappedReportEntries.add(entry));
         }
         if (isMarkedAsNestedTest()) {
             prepareEntriesForNestedTests();
             if (isNestedTestReadyToPrint()) {
                 printNestedTests(getTreePrinter);
-                printTestTree();
             }
         } else {
             printTests(getTreePrinter);
         }
-    }
-
-    private void printTestTree() {
-        new ActualTreePrinter(node).print();
     }
 
     List<String> getTestClassPath(String sourceName) {

--- a/src/main/java/org/apache/maven/plugin/surefire/report/TestReportHandler.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TestReportHandler.java
@@ -1,6 +1,7 @@
 package org.apache.maven.plugin.surefire.report;
 
 import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.SimpleReportEntry;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,6 +44,9 @@ public class TestReportHandler {
         if (testSetStats != null) {
             testSetStats.getReportEntries()
                     .forEach(entry -> Node.getBranchNode(node, getTestClassPath(entry.getSourceName())).get().wrappedReportEntries.add(entry));
+        }
+        if (report != null) {
+            Node.getBranchNode(node, getTestClassPath(report.getSourceName())).get().setClassReportEntry((WrappedReportEntry) report);
         }
         if (isMarkedAsNestedTest()) {
             prepareEntriesForNestedTests();

--- a/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
@@ -77,15 +77,14 @@ public class TreePrinter {
     }
 
     public void printTests() {
-        testSetStats
-                .stream()
-                .map(TestPrinter::new)
-                .forEach(printer -> {
-                    printer.printTest(isSuccessPrintAllowed());
-                    printer.printDetails();
-                });
-        new ActualTreePrinter(Node.getRoot()).print();
-        Node.getRoot().clearTree();
+//        testSetStats
+//                .stream()
+//                .map(TestPrinter::new)
+//                .forEach(printer -> {
+//                    printer.printTest(isSuccessPrintAllowed());
+//                    printer.printDetails();
+//                });
+        new ActualTreePrinter(Node.getRoot(), consoleLogger, options).print();
     }
 
     private boolean isSuccessPrintAllowed() {

--- a/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
@@ -20,12 +20,15 @@
 package org.apache.maven.plugin.surefire.report;
 
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+import org.apache.maven.surefire.shared.lang3.ArrayUtils;
 import org.apache.maven.surefire.shared.lang3.StringUtils;
 import org.apache.maven.surefire.shared.utils.logging.MessageBuilder;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
 import static java.util.stream.Collectors.toList;

--- a/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TreePrinter.java
@@ -84,6 +84,8 @@ public class TreePrinter {
                     printer.printTest(isSuccessPrintAllowed());
                     printer.printDetails();
                 });
+        new ActualTreePrinter(Node.getRoot()).print();
+        Node.getRoot().clearTree();
     }
 
     private boolean isSuccessPrintAllowed() {

--- a/src/test/java/org/apache/maven/plugin/surefire/VeryNestedExampleTest.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/VeryNestedExampleTest.java
@@ -1,0 +1,109 @@
+package org.apache.maven.plugin.surefire;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Very Nested Sample")
+public class VeryNestedExampleTest {
+
+    @Nested
+    @DisplayName("Inner Test")
+    class InnerTest {
+
+        @Test
+        @DisplayName("Inner test should pass")
+        void test() throws InterruptedException {
+            Thread.sleep(200);
+        }
+
+        @Nested
+        @DisplayName("Inner Inner Test")
+        class InnerInnerTest {
+
+            @Test
+            @DisplayName("Inner Inner Test should pass")
+            void test() throws InterruptedException {
+                Thread.sleep(300);
+            }
+
+            @Nested
+            @DisplayName("Inner Inner Inner Test")
+            class InnerInnerInnerTest {
+
+                @Test
+                @DisplayName("Inner Inner Inner Test should pass")
+                void test() throws InterruptedException {
+                    Thread.sleep(400);
+                }
+
+            }
+
+        }
+    }
+
+    @Test
+    @DisplayName("Should pass")
+    void test() throws InterruptedException {
+        Thread.sleep(100);
+    }
+
+    @Nested
+    @DisplayName("First Inner Test")
+    class FirstInnerTest {
+        @Test
+        @DisplayName("FirstInnerTest should show up")
+        void test() throws InterruptedException {
+            Thread.sleep(600);
+        }
+    }
+
+    @Nested
+    @DisplayName("Second Inner Test")
+    class SecondInnerTest {
+
+        @Test
+        @DisplayName("Inner test should pass")
+        void test() throws InterruptedException {
+            Thread.sleep(200);
+        }
+
+        @Nested
+        @DisplayName("Inner Inner Test")
+        class InnerInnerTest {
+
+            @Test
+            @DisplayName("Inner Inner Test should pass")
+            void test() throws InterruptedException {
+                Thread.sleep(300);
+            }
+
+            @Nested
+            @DisplayName("Inner Inner Inner Test")
+            class InnerInnerInnerTest {
+
+                @Test
+                @DisplayName("Inner Inner Inner Test should pass")
+                void test() throws InterruptedException {
+                    Thread.sleep(400);
+                }
+
+            }
+
+        }
+
+        @Test
+        @DisplayName("Second Inner test should pass")
+        void test2() throws InterruptedException {
+            Thread.sleep(200);
+        }
+
+    }
+
+    @Test
+    @DisplayName("Should pass2")
+    void test2() throws InterruptedException {
+        Thread.sleep(500);
+    }
+
+}

--- a/src/test/java/org/apache/maven/plugin/surefire/report/ConsoleTreeReporterTest.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/ConsoleTreeReporterTest.java
@@ -1,6 +1,6 @@
 package org.apache.maven.plugin.surefire.report;
 
-import org.apache.maven.plugin.surefire.NestedExampleTest;
+import org.apache.maven.plugin.surefire.VeryNestedExampleTest;
 import org.apache.maven.plugin.surefire.log.PluginConsoleLogger;
 import org.apache.maven.surefire.api.report.RunMode;
 import org.apache.maven.surefire.api.report.SimpleReportEntry;
@@ -34,7 +34,7 @@ class ConsoleTreeReporterTest {
         // Now we can check the output of any Test class using this
         // TODO: Add some proxy before the logger or something so we can assert the output
         // TODO: Add some objects with relevant information inside the emulator
-        SurefireEmulator surefireEmulator = new SurefireEmulator(NestedExampleTest.class);
+        SurefireEmulator surefireEmulator = new SurefireEmulator(VeryNestedExampleTest.class);
         List<String> logs = surefireEmulator.run();
         assertThat(logs).isNotEmpty();
     }

--- a/src/test/java/org/apache/maven/plugin/surefire/report/ConsoleTreeReporterTest.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/ConsoleTreeReporterTest.java
@@ -114,6 +114,7 @@ class ConsoleTreeReporterTest {
         SimpleReportEntry simpleReportEntry2 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest", "Inner Test", null, null);
         SimpleReportEntry simpleReportEntry3 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest", "Inner Inner Test", null, null);
         SimpleReportEntry simpleReportEntry4 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Inner Inner Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry5 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$FirstInnerTest", "First Inner Test", null, null);
 
         SimpleReportEntry firstTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest", "Nested Sample", "test", "Should not be displayed");
         WrappedReportEntry wrappedReportEntry1 = new WrappedReportEntry(firstTest, ReportEntryType.SUCCESS, 1, stdout, stderr);
@@ -149,10 +150,12 @@ class ConsoleTreeReporterTest {
         consoleTreeReporter.testSetStarting(simpleReportEntry2);
         consoleTreeReporter.testSetStarting(simpleReportEntry3);
         consoleTreeReporter.testSetStarting(simpleReportEntry4);
+        consoleTreeReporter.testSetStarting(simpleReportEntry5);
         consoleTreeReporter.testSetCompleted(wrappedReportEntry5, testSetStats, null);
         consoleTreeReporter.testSetCompleted(wrappedReportEntry4, testSetStatsForClass, null);
         consoleTreeReporter.testSetCompleted(wrappedReportEntry3, testSetStatsForClass, null);
         consoleTreeReporter.testSetCompleted(wrappedReportEntry2, testSetStatsForClass, null);
+        consoleTreeReporter.testSetCompleted(wrappedReportEntry6, testSetStatsForClass, null);
 
     }
 

--- a/src/test/java/org/apache/maven/plugin/surefire/report/ConsoleTreeReporterTest.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/ConsoleTreeReporterTest.java
@@ -8,6 +8,7 @@ import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.logging.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -29,6 +30,11 @@ class ConsoleTreeReporterTest {
         logger = container.getLogger();
     }
 
+    @BeforeEach
+    void cleanNode() {
+        Node.clearTree();
+    }
+
     @Test
     void testEmulator() {
         // Now we can check the output of any Test class using this
@@ -43,9 +49,9 @@ class ConsoleTreeReporterTest {
     void testSetStarting() {
         //Runs 4 times for this class
         SimpleReportEntry simpleReportEntry1 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest", "Nested Sample", null, null);
-        SimpleReportEntry simpleReportEntry2 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest", "Inner Test", null, null);
-        SimpleReportEntry simpleReportEntry3 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest", "Inner Inner Test", null, null);
-        SimpleReportEntry simpleReportEntry4 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Inner Inner Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry2 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest", "Nested Sample Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry3 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest", "Nested Sample Inner Test Inner Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry4 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Nested Sample Inner Test Inner Inner Test Inner Inner Inner Test", null, null);
 
         ConsoleTreeReporter consoleTreeReporter = new ConsoleTreeReporter(new PluginConsoleLogger(logger), ReporterOptions.builder().build());
         consoleTreeReporter.testSetStarting(simpleReportEntry1);
@@ -59,19 +65,19 @@ class ConsoleTreeReporterTest {
 
         //TestStarting parameters
         SimpleReportEntry simpleReportEntry1 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest", "Nested Sample", null, null);
-        SimpleReportEntry simpleReportEntry2 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest", "Inner Test", null, null);
-        SimpleReportEntry simpleReportEntry3 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest", "Inner Inner Test", null, null);
-        SimpleReportEntry simpleReportEntry4 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Inner Inner Inner Test", null, null);
-        SimpleReportEntry simpleReportEntry5 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$FirstInnerTest", "First Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry2 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest", "Nested Sample Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry3 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest", "Nested Sample Inner Test Inner Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry4 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Nested Sample Inner Test Inner Inner Test Inner Inner Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry5 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$FirstInnerTest", "Nested Sample Inner Test Inner Inner Test Inner Inner Inner Test First Inner Test", null, null);
 
         //Runs 1 time with all the information
         //Gets all SingleReportEntries with test names and add on a list of WrapperReportEntries to create a TestSetStats
         SimpleReportEntry firstTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest", "Nested Sample", "test", "Should pass");
         SimpleReportEntry secondTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest", "Nested Sample", "test2", "Should pass2");
-        SimpleReportEntry thirdTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest", "Inner Test", "test", "Inner test should pass");
-        SimpleReportEntry fourthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest", "Inner Inner Test", "test", "Inner Inner Test should pass");
-        SimpleReportEntry fifthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Inner Inner Inner Test", "test", "Inner Inner Inner Test should pass");
-        SimpleReportEntry sixthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$FirstInnerTest", "First Inner Test", "test", "FirstInnerTest should show up");
+        SimpleReportEntry thirdTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest", "Nested Sample Inner Test", "test", "Inner test should pass");
+        SimpleReportEntry fourthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest", "Nested Sample Inner Test Inner Inner Test", "test", "Inner Inner Test should pass");
+        SimpleReportEntry fifthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Nested Sample Inner Test Inner Inner Test Inner Inner Inner Test", "test", "Inner Inner Inner Test should pass");
+        SimpleReportEntry sixthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "org.apache.maven.plugin.surefire.NestedExampleTest$FirstInnerTest", "Nested Sample First Inner Test", "test", "FirstInnerTest should show up");
 
         WrappedReportEntry wrappedReportEntry1 = new WrappedReportEntry(firstTest, ReportEntryType.SUCCESS, 1, stdout, stderr);
         WrappedReportEntry wrappedReportEntry2 = new WrappedReportEntry(secondTest, ReportEntryType.SUCCESS, 1, stdout, stderr);
@@ -111,10 +117,10 @@ class ConsoleTreeReporterTest {
     void testHideSuccess() {
         //TestStarting parameters
         SimpleReportEntry simpleReportEntry1 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest", "Nested Sample", null, null);
-        SimpleReportEntry simpleReportEntry2 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest", "Inner Test", null, null);
-        SimpleReportEntry simpleReportEntry3 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest", "Inner Inner Test", null, null);
-        SimpleReportEntry simpleReportEntry4 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Inner Inner Inner Test", null, null);
-        SimpleReportEntry simpleReportEntry5 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$FirstInnerTest", "First Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry2 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest", "Nested Sample Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry3 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest", "Nested Sample Inner Test Inner Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry4 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Nested Sample Inner Test Inner Inner Test Inner Inner Inner Test", null, null);
+        SimpleReportEntry simpleReportEntry5 = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$FirstInnerTest", "Nested Sample First Inner Test", null, null);
 
         SimpleReportEntry firstTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest", "Nested Sample", "test", "Should not be displayed");
         WrappedReportEntry wrappedReportEntry1 = new WrappedReportEntry(firstTest, ReportEntryType.SUCCESS, 1, stdout, stderr);
@@ -122,16 +128,16 @@ class ConsoleTreeReporterTest {
         SimpleReportEntry secondTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest", "Nested Sample", "test2", "Should not be displayed");
         WrappedReportEntry wrappedReportEntry2 = new WrappedReportEntry(secondTest, ReportEntryType.SUCCESS, 1, stdout, stderr);
 
-        SimpleReportEntry thirdTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest", "Inner Test", "test", "Inner failure test should be displayed");
+        SimpleReportEntry thirdTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest", "Nested Sample Inner Test", "test", "Inner failure test should be displayed");
         WrappedReportEntry wrappedReportEntry3 = new WrappedReportEntry(thirdTest, ReportEntryType.FAILURE, 1, stdout, stderr);
 
-        SimpleReportEntry fourthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest", "Inner Inner Test", "test", "Inner Inner error test should be displayed");
+        SimpleReportEntry fourthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest", "Nested Sample Inner Test Inner Inner Test", "test", "Inner Inner error test should be displayed");
         WrappedReportEntry wrappedReportEntry4 = new WrappedReportEntry(fourthTest, ReportEntryType.ERROR, 1, stdout, stderr);
 
-        SimpleReportEntry fifthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Inner Inner Inner Test", "test", "Inner Inner Inner skipped test should be displayed");
+        SimpleReportEntry fifthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$InnerTest$InnerInnerTest$InnerInnerInnerTest", "Nested Sample Inner Test Inner Inner Test Inner Inner Inner Test", "test", "Inner Inner Inner skipped test should be displayed");
         WrappedReportEntry wrappedReportEntry5 = new WrappedReportEntry(fifthTest, ReportEntryType.SKIPPED, 1, stdout, stderr);
 
-        SimpleReportEntry sixthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$FirstInnerTest", "First Inner Test", "test", "FirstInnerTest should not be displayed");
+        SimpleReportEntry sixthTest = new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, "NestedExampleTest$FirstInnerTest", "Nested Sample First Inner Test", "test", "FirstInnerTest should not be displayed");
         WrappedReportEntry wrappedReportEntry6 = new WrappedReportEntry(sixthTest, ReportEntryType.SUCCESS, 1, stdout, stderr);
 
         TestSetStats testSetStats = new TestSetStats(false, true);

--- a/src/test/java/org/apache/maven/plugin/surefire/report/NodeTest.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/NodeTest.java
@@ -1,0 +1,45 @@
+package org.apache.maven.plugin.surefire.report;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NodeTest {
+
+    @Test
+    void addNode() {
+        //Given I have a empty ROOT
+        Node root = Node.getRoot();
+        assertThat(root.getName()).isEqualTo("ROOT");
+        assertThat(root.branches).isEmpty();
+
+        //When I add 5 children in sequence
+        Node child = root.addChildren("how", "are", "you", "?");
+        assertThat(root.branches).hasSize(1);
+        assertThat(root.branches.get(0).getName()).isEqualTo("how");
+        assertThat(child.getName()).isEqualTo("?");
+        assertThat(child.getParent().getName()).isEqualTo("you");
+
+        //And then add more 3 items in the middle of the tree
+        Node areNode = root.getBranchNode(Lists.newArrayList("how", "are")).get();
+        assertThat(areNode.branches).hasSize(1);
+
+        //I should have a node with two branches in a tree that looks like this
+        /*
+                ROOT
+                 |
+                how
+                 |
+                are
+               /   \
+             you   your
+              |     |
+              ?   parents
+        */
+        Node newChild = areNode.addChildren("your", "parents");
+        assertThat(newChild.getName()).isEqualTo("parents");
+        assertThat(newChild.getParent().getName()).isEqualTo("your");
+        assertThat(areNode.branches).hasSize(2);
+    }
+}

--- a/src/test/java/org/apache/maven/plugin/surefire/report/NodeTest.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/NodeTest.java
@@ -1,11 +1,17 @@
 package org.apache.maven.plugin.surefire.report;
 
 import com.google.common.collect.Lists;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class NodeTest {
+
+    @BeforeEach
+    void setup() {
+       Node.getRoot().clearTree();
+    }
 
     @Test
     void addNode() {

--- a/src/test/java/org/apache/maven/plugin/surefire/report/NodeTest.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/NodeTest.java
@@ -10,7 +10,7 @@ class NodeTest {
 
     @BeforeEach
     void setup() {
-       Node.getRoot().clearTree();
+       Node.clearTree();
     }
 
     @Test

--- a/src/test/java/org/apache/maven/plugin/surefire/report/SurefireEmulator.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/SurefireEmulator.java
@@ -28,7 +28,7 @@ public class SurefireEmulator {
     private final ConsoleTreeReporter consoleTreeReporter;
 
     public SurefireEmulator(Class<?> clazz) {
-        this(ReporterOptions.builder().build(), clazz);
+        this(ReporterOptions.builder().theme(Theme.UNICODE).build(), clazz);
     }
 
     public SurefireEmulator(ReporterOptions reporterOptions, Class<?> clazz) {

--- a/src/test/java/org/apache/maven/plugin/surefire/report/SurefireEmulator.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/SurefireEmulator.java
@@ -11,7 +11,6 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
@@ -75,11 +74,11 @@ public class SurefireEmulator {
                 .forEachOrdered(consoleTreeReporter::testSetStarting);
     }
 
-    private <T> SimpleReportEntry simpleReportEntryGenerator(Class<T> clazz) {
+    private SimpleReportEntry simpleReportEntryGenerator(Class<?> clazz) {
         return new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, clazz.getName(), getClassDisplayName(clazz), null, null);
     }
 
-    private <T> SimpleReportEntry simpleReportEntryGenerator(Class<T> clazz, Method method) {
+    private SimpleReportEntry simpleReportEntryGenerator(Class<?> clazz, Method method) {
         return new SimpleReportEntry(RunMode.NORMAL_RUN, 123L, clazz.getName(), getClassDisplayName(clazz), method.getName(), getMethodDisplayName(clazz, method));
     }
 
@@ -111,24 +110,26 @@ public class SurefireEmulator {
     }
 
     // Got the methods below from JUnit Jupiter codebase DisplayNameUtils.java
-    private String getDisplayName(AnnotatedElement element, Supplier<String> displayNameSupplier) {
+    private String getDisplayName(AnnotatedElement element, Function<Class<?>, String> displayNameSupplier) {
         Optional<DisplayName> displayNameAnnotation = findAnnotation(element, DisplayName.class);
         if (displayNameAnnotation.isPresent()) {
             String displayName = displayNameAnnotation.get().value().trim();
             if (!StringUtils.isBlank(displayName)) return displayName;
         }
-        return displayNameSupplier.get();
+        return displayNameSupplier.apply(element.getClass());
     }
 
-    private <T> String getClassDisplayName(Class<T> clazz) {
+    private String getClassDisplayName(Class<?> clazz) {
         if (clazz.getEnclosingClass() == null) {
-            return getDisplayName(clazz, () -> displayNameGenerator.generateDisplayNameForClass(clazz));
+            return getDisplayName(clazz, displayNameGenerator::generateDisplayNameForClass);
         } else {
-            return getDisplayName(clazz, () -> displayNameGenerator.generateDisplayNameForNestedClass(clazz));
+            return getClassDisplayName(clazz.getEnclosingClass())
+                    .concat(" ")
+                    .concat(getDisplayName(clazz, displayNameGenerator::generateDisplayNameForNestedClass));
         }
     }
 
-    private <T> String getMethodDisplayName(Class<T> clazz, Method method) {
-        return getDisplayName(method, () -> displayNameGenerator.generateDisplayNameForMethod(clazz, method));
+    private String getMethodDisplayName(Class<?> clazz, Method method) {
+        return getDisplayName(method, (ignored) -> displayNameGenerator.generateDisplayNameForMethod(clazz, method));
     }
 }


### PR DESCRIPTION
This change made it easier to work with this code.
Beyond that there were:
- Improvements in the unit tests to copy maven surefire behaviour
- Improvements in printing the name of the methods correctly
- Improvements in making the tree reporter a bit nicer for nested classes and more fixes
- Improvements in the SurefireEmulator
- Fixes #62 
- Fixed #46 