### PR TITLE
Fix NoSuchElementException in TestReportHandler.print() with @Disabled + @TestFactory

### DIFF
--- a/src/main/java/org/apache/maven/plugin/surefire/report/TestReportHandler.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/TestReportHandler.java
@@ -40,11 +40,23 @@ public class TestReportHandler {
 
     public void print(TreePrinter treePrinter) {
         if (testSetStats != null) {
+            // Add report entries only if their corresponding node exists in the tree.
+            // Nodes may be missing when TestSetStats contains entries for sources that were
+            // never registered via testSetStarting() (e.g., @Disabled tests or @TestFactory
+            // dynamic tests with different source names).
             testSetStats.getReportEntries()
-                    .forEach(entry -> Node.getBranchNode(node, getTestClassPath(entry.getSourceName())).get().wrappedReportEntries.add(entry));
+                    .forEach(entry -> Node.getBranchNode(node, getTestClassPath(entry.getSourceName()))
+                            .ifPresent(branchNode -> branchNode.wrappedReportEntries.add(entry)));
         }
 
-        Node classToBeTested = Node.getBranchNode(node, getTestClassPath(report.getSourceName())).get();
+        // Node may not exist if this report's source was never registered via testSetStarting().
+        // This can happen with @Disabled tests or @TestFactory dynamic tests where the source
+        // name differs from what was registered.
+        Optional<Node> optionalNode = Node.getBranchNode(node, getTestClassPath(report.getSourceName()));
+        if (optionalNode.isEmpty()) {
+            return;
+        }
+        Node classToBeTested = optionalNode.get();
         classToBeTested.setClassReportEntry((WrappedReportEntry) report);
 
         if (isMarkedAsNestedTest()) {

--- a/src/test/java/org/apache/maven/plugin/surefire/report/ConsoleTreeReporterTest.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/ConsoleTreeReporterTest.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 class ConsoleTreeReporterTest {
 
@@ -154,6 +155,57 @@ class ConsoleTreeReporterTest {
         consoleTreeReporter.testSetCompleted(wrappedReportEntry2, testSetStatsForClass, null);
         consoleTreeReporter.testSetCompleted(wrappedReportEntry6, testSetStatsForClass, null);
 
+    }
+
+    /**
+     * Reproduces bug: NoSuchElementException in TestReportHandler.print() when TestSetStats
+     * contains entries with source names that were never registered via testSetStarting().
+     *
+     * This occurs with @Disabled tests + @TestFactory dynamic tests when Surefire reports
+     * entries for classes/tests that don't have corresponding nodes in the tree.
+     *
+     * @see <a href="https://github.com/david-waltermire/maven-surefire-junit5-tree-reporter/issues/XX">Issue #XX</a>
+     */
+    @Test
+    void testSetCompletedWithUnregisteredSourceName_shouldNotThrow() {
+        // Register only the main test class - simulate a class with @TestFactory
+        SimpleReportEntry mainClassEntry = new SimpleReportEntry(
+                RunMode.NORMAL_RUN, 123L,
+                "com.example.ExampleTest", "Example Test",
+                null, null);
+
+        // Test entry for the registered class
+        SimpleReportEntry registeredTest = new SimpleReportEntry(
+                RunMode.NORMAL_RUN, 123L,
+                "com.example.ExampleTest", "Example Test",
+                "dynamicTestsWithCollection", "Dynamic Tests");
+        WrappedReportEntry wrappedRegisteredTest = new WrappedReportEntry(
+                registeredTest, ReportEntryType.SUCCESS, 1, stdout, stderr);
+
+        // Test entry for an UNREGISTERED source name - simulates dynamic container or disabled test
+        // that got reported with a different source name than what was registered
+        SimpleReportEntry unregisteredTest = new SimpleReportEntry(
+                RunMode.NORMAL_RUN, 123L,
+                "com.example.UnregisteredClass", "Unregistered Class",
+                "someTest", "Some Test");
+        WrappedReportEntry wrappedUnregisteredTest = new WrappedReportEntry(
+                unregisteredTest, ReportEntryType.SKIPPED, 1, stdout, stderr);
+
+        // TestSetStats contains both registered and unregistered entries
+        TestSetStats testSetStats = new TestSetStats(false, true);
+        testSetStats.testSucceeded(wrappedRegisteredTest);
+        testSetStats.testSkipped(wrappedUnregisteredTest);
+
+        ConsoleTreeReporter consoleTreeReporter = new ConsoleTreeReporter(
+                new PluginConsoleLogger(logger), ReporterOptions.builder().build());
+
+        // Only register the main class
+        consoleTreeReporter.testSetStarting(mainClassEntry);
+
+        // This should NOT throw NoSuchElementException even though testSetStats
+        // contains entries with unregistered source names
+        assertThatNoException().isThrownBy(() ->
+                consoleTreeReporter.testSetCompleted(wrappedRegisteredTest, testSetStats, null));
     }
 
 


### PR DESCRIPTION
## Summary

Fixes a crash (`NoSuchElementException: No value present`) in `TestReportHandler.print()` when a test class contains both `@Disabled` tests and `@TestFactory` dynamic tests.

- The reporter crashes during `testSetCompleted()` when printing results
- Tests execute successfully, but console incorrectly shows "Tests run: 0"
- XML reports are generated correctly; only console output is affected

## Root Cause

In `TestReportHandler.print()`, `Node.getBranchNode()` returns `Optional<Node>`, but the code called `.get()` without checking `isPresent()`:

```java
// Line 44 - crashes when entry's source name has no node
testSetStats.getReportEntries()
    .forEach(entry -> Node.getBranchNode(...).get().wrappedReportEntries.add(entry));

// Line 47 - same issue
Node classToBeTested = Node.getBranchNode(...).get();
```

When `TestSetStats` contains entries for source names that were never registered via `testSetStarting()` (e.g., disabled tests or dynamic tests with different source names), `getBranchNode()` returns `Optional.empty()` and `.get()` throws `NoSuchElementException`.

## Fix

- **Line 44**: Use `.ifPresent()` to safely skip entries without corresponding nodes
- **Line 47**: Check `Optional.isEmpty()` and return early if the node doesn't exist

## Reproduction

A test class with this structure triggers the bug:

```java
class ExampleTest {
    @Disabled
    @Test
    void disabledTest() { }

    @TestFactory
    Stream<DynamicNode> generateTests() {
        return Stream.of(
            DynamicContainer.dynamicContainer("Collection",
                Stream.of(
                    DynamicTest.dynamicTest("Validate Schema", () -> { }),
                    DynamicTest.dynamicTest("Validate Content", () -> { })
                )
            )
        );
    }
}
```

## Test Plan

- [x] Added regression test `testSetCompletedWithUnregisteredSourceName_shouldNotThrow`
- [x] All existing tests pass (40 run, 2 skipped)
- [x] New test fails before fix, passes after fix