### PR TITLE
Optimize branch lookups from `O(n)` to `O(1)` using `HashMap`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.surefire.version>3.5.3</maven.surefire.version>
+        <maven.surefire.version>3.5.4</maven.surefire.version>
         <maven-surefire.testsetInfoReporter>
             org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter
         </maven-surefire.testsetInfoReporter>

--- a/src/main/java/org/apache/maven/plugin/surefire/report/ActualTreePrinter.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/ActualTreePrinter.java
@@ -36,7 +36,7 @@ public class ActualTreePrinter {
     }
 
     public void removeChild() {
-        tree.getParent().branches.remove(tree);
+        tree.getParent().removeBranch(tree);
     }
 
     private void print(Node node) {

--- a/src/main/java/org/apache/maven/plugin/surefire/report/Node.java
+++ b/src/main/java/org/apache/maven/plugin/surefire/report/Node.java
@@ -5,13 +5,16 @@ import org.apache.maven.surefire.api.report.SimpleReportEntry;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class Node {
     private static final Node ROOT = new Node("ROOT", 0);
     final List<Node> branches = new ArrayList<>();
+    private final Map<String, Node> branchMap = new HashMap<>();
     private final Node parent;
     private final String name;
     private final int depth;
@@ -20,6 +23,7 @@ public class Node {
 
     public static void clearTree() {
         ROOT.branches.clear();
+        ROOT.branchMap.clear();
     }
 
     public String getName() {
@@ -36,6 +40,11 @@ public class Node {
 
     public boolean hasBranches() {
        return !branches.isEmpty();
+    }
+
+    public void removeBranch(Node branch) {
+        branches.remove(branch);
+        branchMap.remove(branch.name);
     }
 
     private Node(String name, int nestLevel) {
@@ -71,8 +80,9 @@ public class Node {
     }
 
     private Node generateBranch(String name) {
-        Node branch = new Node(name,this);
+        Node branch = new Node(name, this);
         branches.add(branch);
+        branchMap.put(name, branch);
         return branch;
     }
 
@@ -81,13 +91,11 @@ public class Node {
     }
 
     boolean containsBranch(String reportName) {
-        return branches.stream().anyMatch((item) -> item.name.equals(reportName));
+        return branchMap.containsKey(reportName);
     }
 
     Optional<Node> getBranchNode(String reportName) {
-        return branches.stream()
-                .filter((item) -> item.name.equals(reportName))
-                .findFirst();
+        return Optional.ofNullable(branchMap.get(reportName));
     }
 
     Optional<Node> getBranchNode(List<String> nodePath) {

--- a/src/test/java/org/apache/maven/plugin/surefire/report/NodeTest.java
+++ b/src/test/java/org/apache/maven/plugin/surefire/report/NodeTest.java
@@ -2,7 +2,10 @@ package org.apache.maven.plugin.surefire.report;
 
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,5 +50,161 @@ class NodeTest {
         assertThat(newChild.getName()).isEqualTo("parents");
         assertThat(newChild.getParent().getName()).isEqualTo("your");
         assertThat(areNode.branches).hasSize(2);
+    }
+
+    @Nested
+    class BranchLookupTests {
+
+        @Test
+        void getBranchNode_returnsNodeWhenExists() {
+            Node root = Node.getRoot();
+            root.addChildren("TestClass");
+
+            Optional<Node> result = root.getBranchNode("TestClass");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getName()).isEqualTo("TestClass");
+        }
+
+        @Test
+        void getBranchNode_returnsEmptyWhenNotExists() {
+            Node root = Node.getRoot();
+            root.addChildren("TestClass");
+
+            Optional<Node> result = root.getBranchNode("NonExistentClass");
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void containsBranch_returnsTrueWhenExists() {
+            Node root = Node.getRoot();
+            root.addChildren("TestClass");
+
+            assertThat(root.containsBranch("TestClass")).isTrue();
+        }
+
+        @Test
+        void containsBranch_returnsFalseWhenNotExists() {
+            Node root = Node.getRoot();
+            root.addChildren("TestClass");
+
+            assertThat(root.containsBranch("NonExistentClass")).isFalse();
+        }
+
+        @Test
+        void getBranchNode_withPath_returnsDeepNestedNode() {
+            Node root = Node.getRoot();
+            root.addChildren("OuterClass", "InnerClass", "DeepInnerClass");
+
+            Optional<Node> result = root.getBranchNode(
+                    Lists.newArrayList("OuterClass", "InnerClass", "DeepInnerClass"));
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getName()).isEqualTo("DeepInnerClass");
+        }
+
+        @Test
+        void getBranchNode_withPath_returnsEmptyForPartialPath() {
+            Node root = Node.getRoot();
+            root.addChildren("OuterClass", "InnerClass");
+
+            Optional<Node> result = root.getBranchNode(
+                    Lists.newArrayList("OuterClass", "InnerClass", "NonExistent"));
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void lookupPerformance_withManyBranches() {
+            Node root = Node.getRoot();
+
+            // Add many branches to simulate a large test suite
+            for (int i = 0; i < 1000; i++) {
+                root.addChildren("TestClass" + i);
+            }
+
+            // Lookup should be O(1) with HashMap
+            long startTime = System.nanoTime();
+            for (int i = 0; i < 1000; i++) {
+                assertThat(root.containsBranch("TestClass" + i)).isTrue();
+                assertThat(root.getBranchNode("TestClass" + i)).isPresent();
+            }
+            long duration = System.nanoTime() - startTime;
+
+            // Should complete very quickly with O(1) lookups
+            assertThat(duration).isLessThan(100_000_000L); // 100ms
+        }
+    }
+
+    @Nested
+    class RemoveBranchTests {
+
+        @Test
+        void removeBranch_removesBranchFromListAndMap() {
+            Node root = Node.getRoot();
+            root.addChildren("TestClass1");
+            root.addChildren("TestClass2");
+            root.addChildren("TestClass3");
+
+            Node nodeToRemove = root.getBranchNode("TestClass2").get();
+            root.removeBranch(nodeToRemove);
+
+            assertThat(root.branches).hasSize(2);
+            assertThat(root.containsBranch("TestClass1")).isTrue();
+            assertThat(root.containsBranch("TestClass2")).isFalse();
+            assertThat(root.containsBranch("TestClass3")).isTrue();
+            assertThat(root.getBranchNode("TestClass2")).isEmpty();
+        }
+
+        @Test
+        void removeBranch_maintainsOrderInList() {
+            Node root = Node.getRoot();
+            root.addChildren("First");
+            root.addChildren("Second");
+            root.addChildren("Third");
+
+            Node nodeToRemove = root.getBranchNode("Second").get();
+            root.removeBranch(nodeToRemove);
+
+            assertThat(root.branches).hasSize(2);
+            assertThat(root.branches.get(0).getName()).isEqualTo("First");
+            assertThat(root.branches.get(1).getName()).isEqualTo("Third");
+        }
+
+        @Test
+        void removeBranch_worksForNestedNodes() {
+            Node root = Node.getRoot();
+            root.addChildren("Parent", "Child1");
+            root.addChildren("Parent", "Child2");
+
+            Node parent = root.getBranchNode("Parent").get();
+            Node childToRemove = parent.getBranchNode("Child1").get();
+            parent.removeBranch(childToRemove);
+
+            assertThat(parent.branches).hasSize(1);
+            assertThat(parent.containsBranch("Child1")).isFalse();
+            assertThat(parent.containsBranch("Child2")).isTrue();
+        }
+    }
+
+    @Nested
+    class ClearTreeTests {
+
+        @Test
+        void clearTree_clearsAllBranchesAndMaps() {
+            Node root = Node.getRoot();
+            root.addChildren("Class1");
+            root.addChildren("Class2");
+            root.addChildren("Class3", "Nested");
+
+            Node.clearTree();
+
+            assertThat(root.branches).isEmpty();
+            assertThat(root.containsBranch("Class1")).isFalse();
+            assertThat(root.containsBranch("Class2")).isFalse();
+            assertThat(root.containsBranch("Class3")).isFalse();
+            assertThat(root.getBranchNode("Class1")).isEmpty();
+        }
     }
 }


### PR DESCRIPTION
### Problem

  The Node class uses a `List<Node>` to store child branches and performs lookups using Java Streams with linear search:


```
  Optional<Node> getBranchNode(String reportName) {
      return branches.stream()
              .filter((item) -> item.name.equals(reportName))
              .findFirst();
  }

  boolean containsBranch(String reportName) {
      return branches.stream().anyMatch((item) -> item.name.equals(reportName));
  }
```

  These methods are called during test execution very often:
  - Every time a test class is added to the tree (`addChildren()` calls `getBranchNode()`)
  - Every time nested test detection occurs
  - During tree traversal for printing

  For large test suites with hundreds or thousands of test classes, this results in `O(n²) `complexity during tree construction, causing noticeable performance degradation. Specially at [Picnic modules](https://github.com/PicnicSupermarket) where we have big modules with a lot of tests

  ### Solution

  Introduced a parallel `HashMap<String, Node>` alongside the existing `List<Node> `to provide `O(1)` lookups while preserving insertion order for tree traversal:

  ```
private final Map<String, Node> branchMap = new HashMap<>();

  Optional<Node> getBranchNode(String reportName) {
      return Optional.ofNullable(branchMap.get(reportName));
  }

  boolean containsBranch(String reportName) {
      return branchMap.containsKey(reportName);
  }
```

