### PR TITLE
Remove unused mockito dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,19 +26,11 @@
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mockito-bom.version>4.11.0</mockito-bom.version>
         <junit-bom.version>5.14.0</junit-bom.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-bom</artifactId>
-                <version>${mockito-bom.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>


### PR DESCRIPTION
Mockito is not actually used in either code or tests, so it can be removed.

Removing may help in some situations if there would be incompatible mockito version (for example mockito 5) coming from elsewhere, or possibly some similar problem across transitive dependencies.